### PR TITLE
Add informative eight-ball response

### DIFF
--- a/hotdogbot.py
+++ b/hotdogbot.py
@@ -30,7 +30,8 @@ eight_ball_responses = [
     "Don't count on it, ",
     "No, ",
     "Not a chance, ",
-    "ok, "
+    "ok, ",
+    "what"
 ]
 
 src_messages = [


### PR DESCRIPTION
This commit implements an expansive and informative response when querying. This interrogative pronoun doubles as an adverb, and is used in the "Five W's" as one of the primitive constructors for thorough documentation, research, and investigations. While it's frequently suggested that this list contains six when including "How", the "What" is typically weighed with higher importance. This instance also is explicit sources to the Incompatible Timesharing System information utility (ITS), as well as the Web Hypertext Application Technology. 

It's also a Bo Burnham song that he wrote about eight years ago, and a move that had to be referenced as "The Whip and the Body" in 1963.